### PR TITLE
Use Module.prepend when possible

### DIFF
--- a/lib/jquery-rjs/rendering.rb
+++ b/lib/jquery-rjs/rendering.rb
@@ -1,13 +1,21 @@
 require 'action_view/helpers/rendering_helper'
 
-ActionView::Helpers::RenderingHelper.module_eval do
-  def render_with_update(options = {}, locals = {}, &block)
-    if options == :update
-      update_page(&block)
-    else
-      render_without_update(options, locals, &block)
-    end
+module JqueryRjs::RenderingHelper
+  method_name = "render#{'_with_update' if RUBY_VERSION < '2'}"
+  define_method(method_name) do |options = {}, locals = {}, &block|
+    update_page(&block) if options == :update
+
+    args = options, locals, block
+    RUBY_VERSION < '2' ? render_without_update(*args) : super(*args)
   end
-  
-  alias_method_chain :render, :update
+end
+
+
+if RUBY_VERSION < '2'
+  ActionView::Helpers::RenderingHelper.module_eval do
+    include JqueryRjs::RenderingHelper
+    alias_method_chain :render, :update
+  end
+else
+  ActionView::Helpers::RenderingHelper.prepend(JqueryRjs::RenderingHelper)
 end


### PR DESCRIPTION
This change allows both patches in this gem to utilize Ruby 2's
`Module.prepend` instead of ActiveSupport's `alias_method_chain`
when possible.

Normally I would drop support of Ruby < 2 and just
rely on prepend, but as this gem is largely for legacy purposes
this now allows for both methods depending on the version of Ruby used.

This removes current deprecation warnings with Rails 5 and will allow
continued use of the gem once alias_method_chain is removed from
ActiveSupport.
